### PR TITLE
♻️ Refactor: Migrate from LiveData to Kotlin Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Room](https://img.shields.io/badge/room-%237F52FF.svg?style=for-the-badge&logoColor=white)
 ![Retrofit2](https://img.shields.io/badge/retrofit2-%237F52FF.svg?style=for-the-badge&logoColor=white)
 ![Dagger2](https://img.shields.io/badge/dagger2-%237F52FF.svg?style=for-the-badge&logoColor=white)
+![Flow](https://img.shields.io/badge/Flow-%237F52FF.svg?style=for-the-badge&logoColor=white)
 
 **OpenRouter::client** — Android-приложение для общения с нейросетями через сервис [OpenRouter.ai](https://openrouter.ai/). <br>Проект разработан в **учебных целях** для закрепления  навыков.
 
@@ -35,12 +36,12 @@
 - **Data** (Room, Retrofit, Repositories, Mappers)
 - **DI** (Component, Modules, Scope, Qualifiers)
 
-Реализован MVVM-паттерн (ViewModel + LiveData).
+Реализован MVVM-паттерн (ViewModel + Flow).
 <br>Dependency Injection через Dagger2.
 
 ## Технологический стек
 
-- **Kotlin**, **Android SDK**, **Coroutines**, **ViewBinding**
+- **Kotlin**, **Android SDK**, **Coroutines**, **Flow**, **ViewBinding**
 - **Room** (хранение истории чата и избранных AI-моделей)
 - **Retrofit2** (сетевые запросы к OpenRouter API)
 - **Dagger2** (внедрение зависимостей)

--- a/app/src/main/java/com/nullo/openrouterclient/data/database/aiModels/AiModelsDao.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/data/database/aiModels/AiModelsDao.kt
@@ -1,17 +1,17 @@
 package com.nullo.openrouterclient.data.database.aiModels
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AiModelsDao {
 
     @Query("SELECT * FROM ai_models")
-    fun getModels(): LiveData<List<AiModelDbEntity>>
+    fun getModels(): Flow<List<AiModelDbEntity>>
 
     @Query("SELECT * FROM ai_models LIMIT 1")
     suspend fun getDefaultViewModel(): AiModelDbEntity

--- a/app/src/main/java/com/nullo/openrouterclient/data/database/aiModels/AiModelsProvider.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/data/database/aiModels/AiModelsProvider.kt
@@ -42,4 +42,6 @@ class AiModelsProvider @Inject constructor() {
             freeToUse = true,
         ),
     )
+
+    fun getDefaultModel() = defaultModels.first()
 }

--- a/app/src/main/java/com/nullo/openrouterclient/data/database/chat/ChatDao.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/data/database/chat/ChatDao.kt
@@ -1,18 +1,18 @@
 package com.nullo.openrouterclient.data.database.chat
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChatDao {
 
     @Query("SELECT * FROM messages")
-    fun getMessages(): LiveData<List<MessageDbEntity>>
+    fun getMessages(): Flow<List<MessageDbEntity>>
 
     @Query("SELECT * FROM messages WHERE id = :id LIMIT 1")
     suspend fun getMessageById(id: Long): MessageDbEntity?

--- a/app/src/main/java/com/nullo/openrouterclient/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/data/repository/ChatRepositoryImpl.kt
@@ -1,7 +1,5 @@
 package com.nullo.openrouterclient.data.repository
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.map
 import com.nullo.openrouterclient.data.ErrorResponseProvider
 import com.nullo.openrouterclient.data.database.chat.ChatDao
 import com.nullo.openrouterclient.data.database.chat.MessageDbEntityProvider
@@ -14,6 +12,11 @@ import com.nullo.openrouterclient.domain.entities.ChatResponseResult
 import com.nullo.openrouterclient.domain.entities.Message
 import com.nullo.openrouterclient.domain.entities.Message.Query
 import com.nullo.openrouterclient.domain.repositories.ChatRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 class ChatRepositoryImpl @Inject constructor(
@@ -23,15 +26,18 @@ class ChatRepositoryImpl @Inject constructor(
     private val errorResponseProvider: ErrorResponseProvider,
     private val messageMapper: MessageMapper,
     private val apiResponseMapper: ApiResponseMapper,
+    private val coroutineScope: CoroutineScope,
 ) : ChatRepository {
 
-    override fun getMessages(): LiveData<List<Message>> {
-        return chatDao.getMessages().map {
-            it.map { messageDbEntity ->
-                messageMapper.mapDbEntityToMessage(messageDbEntity)
-            }
+    override val messages: StateFlow<List<Message>> = chatDao.getMessages()
+        .map { entityList ->
+            entityList.map { messageMapper.mapDbEntityToMessage(it) }
         }
-    }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.Lazily,
+            initialValue = emptyList()
+        )
 
     override suspend fun addLoadingMessage(): Long {
         val loadingMessage = messageDbEntityProvider.createLoadingMessage()

--- a/app/src/main/java/com/nullo/openrouterclient/di/ApplicationComponent.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/di/ApplicationComponent.kt
@@ -1,6 +1,7 @@
 package com.nullo.openrouterclient.di
 
 import android.app.Application
+import com.nullo.openrouterclient.di.modules.CoroutineScopeModule
 import com.nullo.openrouterclient.di.modules.DataModule
 import com.nullo.openrouterclient.di.modules.DatabaseModule
 import com.nullo.openrouterclient.di.modules.MarkwonModule
@@ -21,7 +22,8 @@ import dagger.Component
         SharedPreferencesModule::class,
         ViewModelModule::class,
         DataModule::class,
-        MarkwonModule::class
+        MarkwonModule::class,
+        CoroutineScopeModule::class
     ]
 )
 @ApplicationScope

--- a/app/src/main/java/com/nullo/openrouterclient/di/modules/CoroutineScopeModule.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/di/modules/CoroutineScopeModule.kt
@@ -1,0 +1,18 @@
+package com.nullo.openrouterclient.di.modules
+
+import com.nullo.openrouterclient.di.ApplicationScope
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+@Module
+class CoroutineScopeModule {
+
+    @Provides
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    }
+}

--- a/app/src/main/java/com/nullo/openrouterclient/domain/repositories/AiModelsRepository.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/repositories/AiModelsRepository.kt
@@ -1,11 +1,11 @@
 package com.nullo.openrouterclient.domain.repositories
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.entities.AiModel
+import kotlinx.coroutines.flow.StateFlow
 
 interface AiModelsRepository {
 
-    fun getPinnedAiModels(): LiveData<List<AiModel>>
+    val pinnedAiModels: StateFlow<List<AiModel>>
 
     suspend fun getCloudAiModels(): List<AiModel>
 

--- a/app/src/main/java/com/nullo/openrouterclient/domain/repositories/ChatRepository.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/repositories/ChatRepository.kt
@@ -1,14 +1,14 @@
 package com.nullo.openrouterclient.domain.repositories
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.entities.AiModel
 import com.nullo.openrouterclient.domain.entities.ChatResponseResult
 import com.nullo.openrouterclient.domain.entities.Message
 import com.nullo.openrouterclient.domain.entities.Message.Query
+import kotlinx.coroutines.flow.StateFlow
 
 interface ChatRepository {
 
-    fun getMessages(): LiveData<List<Message>>
+    val messages: StateFlow<List<Message>>
 
     suspend fun addLoadingMessage(): Long
 

--- a/app/src/main/java/com/nullo/openrouterclient/domain/repositories/SettingsRepository.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/repositories/SettingsRepository.kt
@@ -1,15 +1,15 @@
 package com.nullo.openrouterclient.domain.repositories
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.entities.AiModel
+import kotlinx.coroutines.flow.StateFlow
 
 interface SettingsRepository {
 
-    val currentModel: LiveData<AiModel>
+    val currentModel: StateFlow<AiModel>
 
-    val contextEnabled: LiveData<Boolean>
+    val contextEnabled: StateFlow<Boolean>
 
-    val apiKey: LiveData<String>
+    val apiKey: StateFlow<String>
 
     fun selectAiModel(aiModel: AiModel)
 

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/chat/GetChatMessagesUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/chat/GetChatMessagesUseCase.kt
@@ -1,15 +1,15 @@
 package com.nullo.openrouterclient.domain.usecases.chat
 
-import androidx.lifecycle.LiveData
-import com.nullo.openrouterclient.domain.repositories.ChatRepository
 import com.nullo.openrouterclient.domain.entities.Message
+import com.nullo.openrouterclient.domain.repositories.ChatRepository
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 class GetChatMessagesUseCase @Inject constructor(
     private val repository: ChatRepository
 ) {
 
-    operator fun invoke(): LiveData<List<Message>> {
-        return repository.getMessages()
+    operator fun invoke(): StateFlow<List<Message>> {
+        return repository.messages
     }
 }

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/chat/SendQueryUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/chat/SendQueryUseCase.kt
@@ -1,10 +1,10 @@
 package com.nullo.openrouterclient.domain.usecases.chat
 
-import com.nullo.openrouterclient.domain.repositories.ChatRepository
 import com.nullo.openrouterclient.domain.entities.AiModel
 import com.nullo.openrouterclient.domain.entities.ChatResponseResult
 import com.nullo.openrouterclient.domain.entities.Message
 import com.nullo.openrouterclient.domain.entities.Message.Query
+import com.nullo.openrouterclient.domain.repositories.ChatRepository
 import javax.inject.Inject
 
 class SendQueryUseCase @Inject constructor(
@@ -34,7 +34,7 @@ class SendQueryUseCase @Inject constructor(
                     chatRepository.replaceLoadingWithError(responseResult, loadingMessageId)
                 }
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             chatRepository.replaceLoadingWithNetworkError(loadingMessageId)
         }
     }

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetCloudAiModelsUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetCloudAiModelsUseCase.kt
@@ -1,7 +1,7 @@
 package com.nullo.openrouterclient.domain.usecases.models
 
-import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import com.nullo.openrouterclient.domain.entities.AiModel
+import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import javax.inject.Inject
 
 class GetCloudAiModelsUseCase @Inject constructor(

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetCurrentAiModelUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetCurrentAiModelUseCase.kt
@@ -1,15 +1,15 @@
 package com.nullo.openrouterclient.domain.usecases.models
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.entities.AiModel
 import com.nullo.openrouterclient.domain.repositories.SettingsRepository
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 class GetCurrentAiModelUseCase @Inject constructor(
     private val repository: SettingsRepository
 ) {
 
-    operator fun invoke(): LiveData<AiModel> {
+    operator fun invoke(): StateFlow<AiModel> {
         return repository.currentModel
     }
 }

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetPinnedAiModelsUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/GetPinnedAiModelsUseCase.kt
@@ -1,15 +1,15 @@
 package com.nullo.openrouterclient.domain.usecases.models
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.entities.AiModel
 import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 class GetPinnedAiModelsUseCase @Inject constructor(
     private val repository: AiModelsRepository
 ) {
 
-    operator fun invoke(): LiveData<List<AiModel>> {
-        return repository.getPinnedAiModels()
+    operator fun invoke(): StateFlow<List<AiModel>> {
+        return repository.pinnedAiModels
     }
 }

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/PinAiModelUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/PinAiModelUseCase.kt
@@ -1,7 +1,7 @@
 package com.nullo.openrouterclient.domain.usecases.models
 
-import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import com.nullo.openrouterclient.domain.entities.AiModel
+import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import javax.inject.Inject
 
 class PinAiModelUseCase @Inject constructor(

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/UnpinAiModelUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/models/UnpinAiModelUseCase.kt
@@ -1,7 +1,7 @@
 package com.nullo.openrouterclient.domain.usecases.models
 
-import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import com.nullo.openrouterclient.domain.entities.AiModel
+import com.nullo.openrouterclient.domain.repositories.AiModelsRepository
 import javax.inject.Inject
 
 class UnpinAiModelUseCase @Inject constructor(

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/settings/GetApiKeyUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/settings/GetApiKeyUseCase.kt
@@ -1,14 +1,14 @@
 package com.nullo.openrouterclient.domain.usecases.settings
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.repositories.SettingsRepository
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 class GetApiKeyUseCase @Inject constructor(
     private val repository: SettingsRepository
 ) {
 
-    operator fun invoke(): LiveData<String> {
+    operator fun invoke(): StateFlow<String> {
         return repository.apiKey
     }
 }

--- a/app/src/main/java/com/nullo/openrouterclient/domain/usecases/settings/GetContextEnabledUseCase.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/domain/usecases/settings/GetContextEnabledUseCase.kt
@@ -1,14 +1,14 @@
 package com.nullo.openrouterclient.domain.usecases.settings
 
-import androidx.lifecycle.LiveData
 import com.nullo.openrouterclient.domain.repositories.SettingsRepository
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 class GetContextEnabledUseCase @Inject constructor(
     private val repository: SettingsRepository
 ) {
 
-    operator fun invoke(): LiveData<Boolean> {
+    operator fun invoke(): StateFlow<Boolean> {
         return repository.contextEnabled
     }
 }

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/MainActivity.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/MainActivity.kt
@@ -87,13 +87,13 @@ class MainActivity : AppCompatActivity() {
     private fun observeViewModel() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                launch { observeUiState() }
-                launch { observeUiEvents() }
+                launch { collectUiState() }
+                launch { collectUiEvents() }
             }
         }
     }
 
-    private suspend fun observeUiState() {
+    private suspend fun collectUiState() {
         viewModel.uiState.collect { state ->
             updateMessages(state.messages)
             updateCurrentAiModel(state.currentAiModel)
@@ -120,7 +120,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private suspend fun observeUiEvents() {
+    private suspend fun collectUiEvents() {
         viewModel.uiEvents.collect { event ->
             when (event) {
                 is ShowMessage -> showMessage(getString(event.messageStringRes))

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/UiEvent.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/UiEvent.kt
@@ -1,0 +1,8 @@
+package com.nullo.openrouterclient.presentation
+
+import androidx.annotation.StringRes
+
+sealed class UiEvent {
+    data class ShowError(val error: ErrorType) : UiEvent()
+    data class ShowMessage(@param:StringRes val messageStringRes: Int) : UiEvent()
+}

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/UiState.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/UiState.kt
@@ -1,0 +1,15 @@
+package com.nullo.openrouterclient.presentation
+
+import com.nullo.openrouterclient.domain.entities.AiModel
+import com.nullo.openrouterclient.domain.entities.Message
+
+data class UiState(
+    val messages: List<Message> = emptyList(),
+    val pinnedAiModels: List<AiModel> = emptyList(),
+    val cloudAiModels: List<AiModel> = emptyList(),
+    val currentAiModel: AiModel? = null,
+    val contextEnabled: Boolean = false,
+    val apiKey: String = "",
+    val waitingForResponse: Boolean = false,
+    val loadingCloudAiModels: Boolean = false,
+)

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/aimodels/SelectModelFragment.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/aimodels/SelectModelFragment.kt
@@ -103,12 +103,12 @@ class SelectModelFragment : BottomSheetDialogFragment() {
     private fun observeViewModel() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                observeUiState()
+                collectUiState()
             }
         }
     }
 
-    private suspend fun observeUiState() {
+    private suspend fun collectUiState() {
         viewModel.uiState.collect { state ->
             binding.pbCloudLoading.isVisible = state.loadingCloudAiModels
             pinnedAiModelsAdapter.submitList(state.pinnedAiModels)

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/settings/SettingsFragment.kt
@@ -57,12 +57,12 @@ class SettingsFragment : BottomSheetDialogFragment() {
     private fun observeViewModel() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                observeUiState()
+                collectUiState()
             }
         }
     }
 
-    private suspend fun observeUiState() {
+    private suspend fun collectUiState() {
         viewModel.uiState.collect { state ->
             with(binding) {
                 etApiKey.setText(state.apiKey)

--- a/app/src/main/java/com/nullo/openrouterclient/presentation/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/nullo/openrouterclient/presentation/settings/SettingsFragment.kt
@@ -6,11 +6,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.nullo.openrouterclient.databinding.FragmentSettingsBinding
 import com.nullo.openrouterclient.di.ViewModelFactory
-import com.nullo.openrouterclient.presentation.OpenRouterClientApp
 import com.nullo.openrouterclient.presentation.MainViewModel
+import com.nullo.openrouterclient.presentation.OpenRouterClientApp
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class SettingsFragment : BottomSheetDialogFragment() {
@@ -51,15 +55,19 @@ class SettingsFragment : BottomSheetDialogFragment() {
     }
 
     private fun observeViewModel() {
-        viewModel.apiKey.observe(viewLifecycleOwner) {
-            binding.etApiKey.apply {
-                setText(it)
-                requestFocus()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                observeUiState()
             }
         }
+    }
 
-        viewModel.messages.observe(viewLifecycleOwner) {
-            binding.btnClearChat.isEnabled = it.isNotEmpty()
+    private suspend fun observeUiState() {
+        viewModel.uiState.collect { state ->
+            with(binding) {
+                etApiKey.setText(state.apiKey)
+                btnClearChat.isEnabled = state.messages.isNotEmpty()
+            }
         }
     }
 


### PR DESCRIPTION
## 📝 Description  
Replaced `LiveData` with `Flow` across the codebase.  

## 🔍 Changes
- Replaced `LiveData` with `StateFlow` / `SharedFlow`
- Updated Activities and Fragments to collect `Flows` using `repeatOnLifecycle`
- Used `stateIn` / `shareIn` where cold→hot conversion was required

## 🤔 Why?  
- **Consistency**: Single reactive stream API (`Flow`) for all layers  
- **Modern Android**: Aligns with Google’s recommendations for coroutines  
- **Flexibility**: `Flow` supports richer operators (`map`, `combine`, etc.)  
- **Performance**: Avoids `LiveData`'s limitations (e.g., threading)